### PR TITLE
Issue 330: Fix BashRunner hanging on Linux

### DIFF
--- a/src/TextCopy/BashRunner.cs
+++ b/src/TextCopy/BashRunner.cs
@@ -1,14 +1,11 @@
 #if (NETSTANDARD || NETFRAMEWORK)
 using System;
 using System.Diagnostics;
-using System.Text;
 
 static class BashRunner
 {
-    public static string Run(string commandLine)
+    public static void Run(string commandLine)
     {
-        var errorBuilder = new StringBuilder();
-        var outputBuilder = new StringBuilder();
         var arguments = $"-c \"{commandLine}\"";
         using var process = new Process
         {
@@ -16,8 +13,6 @@ static class BashRunner
             {
                 FileName = "bash",
                 Arguments = arguments,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = false,
             }
@@ -30,19 +25,15 @@ static class BashRunner
         // Context as to why WaitForExit(x) won't reliably print stdout/stderr: https://github.com/dotnet/runtime/issues/27128
         if (!process.WaitForExit(500))
         {
-            var timeoutError = $@"Process timed out. Command line: bash {arguments}.
-Output: {outputBuilder}
-Error: {errorBuilder}";
+            var timeoutError = $@"Process timed out. Command line: bash {arguments}";
             throw new Exception(timeoutError);
         }
         if (process.ExitCode == 0)
         {
-            return outputBuilder.ToString();
+            return;
         }
 
-        var error = $@"Could not execute process. Command line: bash {arguments}.
-Output: {outputBuilder}
-Error: {errorBuilder}";
+        var error = $@"Could not execute process. Command line: bash {arguments} Exit code: {process.ExitCode}";
         throw new Exception(error);
     }
 }

--- a/src/TextCopy/BashRunner.cs
+++ b/src/TextCopy/BashRunner.cs
@@ -23,12 +23,11 @@ static class BashRunner
             }
         };
         process.Start();
-        
-        // xclip communicates clipboard contents by spawning a child process, which results in the stdout and stderr
-        // file handles not being closed, and so process.WaitForExit() (which would wait for stdout) will never exit,
-        // as a result it's problematic to try to print stdout from xclip.
-        // Context as to why WaitForExit(x) won't reliably print stdout/stderr: https://github.com/dotnet/runtime/issues/27128
-        if (!process.WaitForExit(500))
+        process.OutputDataReceived += (sender, args) => { outputBuilder.AppendLine(args.Data); };
+        process.BeginOutputReadLine();
+        process.ErrorDataReceived += (sender, args) => { errorBuilder.AppendLine(args.Data); };
+        process.BeginErrorReadLine();
+        if (!process.DoubleWaitForExit())
         {
             var timeoutError = $@"Process timed out. Command line: bash {arguments}.
 Output: {outputBuilder}
@@ -44,6 +43,17 @@ Error: {errorBuilder}";
 Output: {outputBuilder}
 Error: {errorBuilder}";
         throw new Exception(error);
+    }
+
+    //To work around https://github.com/dotnet/runtime/issues/27128
+    static bool DoubleWaitForExit(this Process process)
+    {
+        var result = process.WaitForExit(500);
+        if (result)
+        {
+            process.WaitForExit();
+        }
+        return result;
     }
 }
 #endif

--- a/src/TextCopy/LinuxClipboard_2.0.cs
+++ b/src/TextCopy/LinuxClipboard_2.0.cs
@@ -18,7 +18,7 @@ static class LinuxClipboard
         File.WriteAllText(tempFileName, text);
         try
         {
-            BashRunner.Run($"cat {tempFileName} | xclip -i -selection clipboard");
+            BashRunner.Run($"cat {tempFileName} | xsel -i --clipboard");
         }
         finally
         {
@@ -36,7 +36,7 @@ static class LinuxClipboard
         var tempFileName = Path.GetTempFileName();
         try
         {
-            BashRunner.Run($"xclip -o -selection clipboard > {tempFileName}");
+            BashRunner.Run($"xsel -o --clipboard > {tempFileName}");
             var readAllText = File.ReadAllText(tempFileName);
             // ReSharper disable once RedundantTypeArgumentsOfMethod
             return readAllText;

--- a/src/TextCopy/LinuxClipboard_2.1.cs
+++ b/src/TextCopy/LinuxClipboard_2.1.cs
@@ -16,7 +16,7 @@ static class LinuxClipboard
                 return;
             }
 
-            BashRunner.Run($"cat {tempFileName} | xclip -i -selection clipboard");
+            BashRunner.Run($"cat {tempFileName} | xsel -i --clipboard ");
         }
         finally
         {
@@ -30,7 +30,7 @@ static class LinuxClipboard
         File.WriteAllText(tempFileName, text);
         try
         {
-            BashRunner.Run($"cat {tempFileName} | xclip -i -selection clipboard");
+            BashRunner.Run($"cat {tempFileName} | xsel -i --clipboard ");
         }
         finally
         {
@@ -43,7 +43,7 @@ static class LinuxClipboard
         var tempFileName = Path.GetTempFileName();
         try
         {
-            BashRunner.Run($"xclip -o -selection clipboard > {tempFileName}");
+            BashRunner.Run($"xsel -o --clipboard > {tempFileName}");
             return File.ReadAllText(tempFileName);
         }
         finally
@@ -57,7 +57,7 @@ static class LinuxClipboard
         var tempFileName = Path.GetTempFileName();
         try
         {
-            BashRunner.Run($"xclip -o -selection clipboard > {tempFileName}");
+            BashRunner.Run($"xsel -o --clipboard  > {tempFileName}");
             return await File.ReadAllTextAsync(tempFileName, cancellation);
         }
         finally


### PR DESCRIPTION
 - `Simple` testcase fails on Ubunu before this change, and is fixed afterwards https://github.com/CopyText/TextCopy/blob/master/src/Tests/ClipboardTests.cs#L9
 - Looks like this hasn't been noticed as the Linux testing on travis hasn't been running, and the AppVeyor CI doesn't run the tests for Linux (https://github.com/CopyText/TextCopy/blob/master/src/appveyor.yml)
 - `xsel` isn't pre-installed on all distros (e.g. Ubuntu 18.4), but I've verified that you get a decent error message when it's missing.

I'll leave fixing up the CI to you @SimonCropp. 