### PR TITLE
Performance enhancement: do not load profile when using powershell Get-Clipboard

### DIFF
--- a/src/TextCopy/LinuxClipboard_2.0.cs
+++ b/src/TextCopy/LinuxClipboard_2.0.cs
@@ -49,7 +49,7 @@ static class LinuxClipboard
         {
             if (isWsl)
             {
-                BashRunner.Run($"powershell.exe Get-Clipboard  > {tempFileName}");
+                BashRunner.Run($"powershell.exe -NoProfile Get-Clipboard  > {tempFileName}");
             }
             else
             {

--- a/src/TextCopy/LinuxClipboard_2.1.cs
+++ b/src/TextCopy/LinuxClipboard_2.1.cs
@@ -80,7 +80,7 @@ static class LinuxClipboard
     {
         if (isWsl)
         {
-            BashRunner.Run($"powershell.exe Get-Clipboard  > {tempFileName}");
+            BashRunner.Run($"powershell.exe -NoProfile Get-Clipboard  > {tempFileName}");
         }
         else
         {


### PR DESCRIPTION
This improves performance (no longer having to wait for the user profile to load and execute) when using powershell Get-Clipboard under WSL; it also prevents failure or unexpected side-effects should the user's profile redefine Get-Clipboard.
