### PR TITLE
Fixed: Addressed the issue where an extra \0 was included in the copy results for Adobe Acrobat Pro

### DIFF
--- a/src/TextCopy/WindowsClipboard.cs
+++ b/src/TextCopy/WindowsClipboard.cs
@@ -149,7 +149,9 @@ static class WindowsClipboard
 
             Marshal.Copy(pointer, buff, 0, size);
 
-            return Encoding.Unicode.GetString(buff).TrimEnd('\0');
+            var result = Encoding.Unicode.GetString(buff);
+            var nullCharIndex = result.IndexOf('\0');
+            return nullCharIndex == -1 ? result : result[..nullCharIndex];
         }
         finally
         {


### PR DESCRIPTION
On Windows, when I open a PDF file with Adobe Acrobat Pro, the text I get has one more '\0' than the text I get when I open the PDF file with Chrome or FireFox. Then I use the [GetText](https://github.com/CopyText/TextCopy/blob/main/src/TextCopy/WindowsClipboard.cs#L152) method provided by this library to get the text. The final result shows a special symbol (�)

The current code solves the problem